### PR TITLE
Remove dependency on `cljx-sampling`

### DIFF
--- a/.wallbrew/sealog/changes/3-4-0.edn
+++ b/.wallbrew/sealog/changes/3-4-0.edn
@@ -1,0 +1,12 @@
+{:version      {:major 3
+                :minor 4
+                :patch 0}
+ :version-type :semver3
+ :changes      {:added      ["Ingredient sampling functions `brew-bot.sampling.api/sample` and `brew-bot.sampling.api/weighted-sample`."
+                             "A macro `brew-bot.sampling.api/with-seed` to set a seed for the internal random generator over multiple sampling calls."]
+                :changed    []
+                :deprecated []
+                :removed    ["Dependency on `cljx-sampling` has been removed."]
+                :fixed      []
+                :security   []}
+ :timestamp    "2024-10-16T22:50:03.860273568Z"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Table of Contents
 
+* [3.4.0 - 2024-10-16](#340---2024-10-16)
 * [3.3.0 - 2024-09-20](#330---2024-09-20)
 * [3.2.2 - 2024-09-14](#322---2024-09-14)
 * [3.2.1 - 2024-03-10](#321---2024-03-10)
@@ -17,6 +18,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [2.0.0 - 2019-10523](#200---2019-10523)
 * [1.0.0 - 2019-10-12](#100---2019-10-12)
 * [0.0.0 - 2019-07-13](#000---2019-07-13)
+
+## 3.4.0 - 2024-10-16
+
+* Added
+  * Ingredient sampling functions `brew-bot.sampling.api/sample` and `brew-bot.sampling.api/weighted-sample`.
+  * A macro `brew-bot.sampling.api/with-seed` to set a seed for the internal random generator over multiple sampling calls.
+* Removed
+  * Dependency on `cljx-sampling` has been removed.
 
 ## 3.3.0 - 2024-09-20
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.wallbrew</groupId>
   <artifactId>brew-bot</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
   <name>brew-bot</name>
   <description>A library to generate randomized beer recipes.</description>
   <url>https://github.com/Wall-Brew-Co/brew-bot</url>
@@ -20,7 +20,7 @@
     <url>https://github.com/Wall-Brew-Co/brew-bot</url>
     <connection>scm:git:git://github.com/Wall-Brew-Co/brew-bot.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Wall-Brew-Co/brew-bot.git</developerConnection>
-    <tag>89f69dec41da74318a7f8b62fbeebabd54869ccd</tag>
+    <tag>d8cc43d4dd696f59be284cc823c60a64650d0f99</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -66,11 +66,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>cljx-sampling</groupId>
-      <artifactId>cljx-sampling</artifactId>
-      <version>0.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.wallbrew</groupId>
       <artifactId>brewtility</artifactId>
       <version>2.2.1</version>
@@ -86,9 +81,9 @@
       <version>2.4.1</version>
     </dependency>
     <dependency>
-      <groupId>nnichols</groupId>
-      <artifactId>nnichols</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.wallbrew</groupId>
+      <artifactId>spoon</artifactId>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.wallbrew/brew-bot "3.3.0"
+(defproject com.wallbrew/brew-bot "3.4.0"
   :description "A library to generate randomized beer recipes."
   :url "https://github.com/Wall-Brew-Co/brew-bot"
   :license {:name         "MIT"

--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,10 @@
   :pom-addition [:organization
                  [:name "Wall Brew Co."]
                  [:url "https://wallbrew.com"]]
-  :dependencies [[cljx-sampling "0.1.0"]
-                 [com.wallbrew/brewtility "2.2.1"]
+  :dependencies [[com.wallbrew/brewtility "2.2.1"]
                  [com.wallbrew/common-beer-data "1.6.0"]
                  [com.wallbrew/common-beer-format "2.4.1"]
-                 [nnichols "1.1.0"]
+                 [com.wallbrew/spoon "1.4.0"]
                  [org.clojure/clojure "1.12.0"]
                  [org.clojure/clojurescript "1.11.132" :scope "provided"]]
 
@@ -33,8 +32,7 @@
   :aliases {"test-build" ["do" "clean" ["cljsbuild" "once" "test"] ["doo" "once"] ["test"]]}
 
   :profiles {:uberjar {:aot :all}
-             :dev     {:dependencies [[com.wallbrew/spoon "1.4.0"]
-                                      [doo/doo "0.1.11"]]
+             :dev     {:dependencies [[doo/doo "0.1.11"]]
                        :plugins      [[lein-doo/lein-doo "0.1.11"]]}}
 
   :min-lein-version "2.5.3"

--- a/src/brew_bot/default_values.cljc
+++ b/src/brew_bot/default_values.cljc
@@ -1,9 +1,14 @@
 (ns brew-bot.default-values
   "Default values for beer recipe generators"
-  (:require [common-beer-format.hops :as hops]))
+  (:require [common-beer-format.hops :as hops]
+            [common-beer-format.mash :as mash]
+            [common-beer-format.recipes :as recipe]))
 
 
-(def common-beer-format-version 1)
+(def common-beer-format-version
+  "The BeerXML version this library is based on."
+  1)
+
 
 (def amount-cutoff 2.26796) ; 5 pounds in kilograms
 
@@ -80,23 +85,23 @@
 
 
 (def common-beer-format-default-mash
-  {:name       "Single Step Infusion"
-   :version    common-beer-format-version
-   :grain-temp 22.0
-   :mash-steps [{:mash-step {:name          "Sugar Conversion Step"
-                             :version       common-beer-format-version
-                             :type          "Infusion"
-                             :step-temp     68.0
-                             :step-time     60.0
-                             :infuse-amount 10.0}}]})
+  {mash/name       "Single Step Infusion"
+   mash/version    common-beer-format-version
+   mash/grain-temp 22.0
+   mash/mash-steps [{mash/mash-step {mash/name          "Sugar Conversion Step"
+                                     mash/version       common-beer-format-version
+                                     mash/type          mash/infusion
+                                     mash/step-temp     68.0
+                                     mash/step-time     60.0
+                                     mash/infuse-amount 10.0}}]})
 
 
 (def common-beer-format-recipe-defaults
-  {:name         "My Recipe"
-   :version      common-beer-format-version
-   :brewer       "brew-bot"
-   :batch-size   19 ; Roughly 5 gallons, common homebrew size
-   :boil-size    19 ; Roughly 5 gallons, common homebrew size
-   :miscs        []
-   :waters       []
-   :mash         common-beer-format-default-mash})
+  {recipe/name       "My Recipe"
+   recipe/version    common-beer-format-version
+   recipe/brewer     "brew-bot"
+   recipe/batch-size 19 ; Roughly 5 gallons, common homebrew size
+   recipe/boil-size  19 ; Roughly 5 gallons, common homebrew size
+   recipe/miscs      []
+   recipe/waters     []
+   recipe/mash       common-beer-format-default-mash})

--- a/src/brew_bot/sampling/api.cljc
+++ b/src/brew_bot/sampling/api.cljc
@@ -1,0 +1,114 @@
+(ns brew-bot.sampling.api
+  (:require [brew-bot.sampling.impl :as impl]))
+
+
+(def ^:dynamic ^:private
+  *global-generator*
+  "A thread-local random number generator."
+  nil)
+
+
+(defmacro with-seed
+  "Execute `body` with a seed for the internal random generator over the scope of the `body`.
+   Note, this is a dynamic var and will only affect the current thread.
+
+   This reuses the same generator for the duration of the execution of body, allowing multiple calls to `sample` and `weighted-sample` to be reproducible.
+   If a seed is already set for `sample` or `sample-weighted`, it will be replaced for the duration of the execution of `body`.
+
+   For example:
+   ```clj
+   (with-seed 12
+     (apply str (take 25 (sut/sample \"abcde\"))) ;=> \"caaebcdeccabaaccaeeabdbcd\"
+     (apply str (take 25 (sut/sample 2 \"fghij\"))) ;=> \"jhihffggjjjhijgjjjjghjfji\")
+   ```"
+  [seed & body]
+  `(binding [*global-generator* (impl/->generator ~seed)]
+     ~@body))
+
+
+(defn sample
+  "Returns a lazy sequence of samples from `coll` using an internal random generator.
+   Requires that `coll` is a finite, countable collection that can be realized.
+   If `coll` is empty, an empty sequence is returned.
+   A seed can be provided to create reproducible sequences, otherwise a random seed is used.
+
+   Examples:
+
+   ```clj
+   (take 5 (sample 1 \"abcde\"))
+   ; => (\\a \\e \\b \\d \\a)
+
+   (take 3 (sample \"hello\" (range 99)))
+   ; => (6 97 18)
+   ```
+
+   `coll` can be:
+      - a vector
+      - a list
+      - a finite lazy sequence
+      - a set
+      - a hashmap
+      - a string
+
+   `seed` can be any value that can be cast to a string."
+  ([coll]
+   (if (seq coll)
+     (sample impl/generate-seed coll)
+     '()))
+  ([seed coll]
+   (assert (seqable? coll) "`coll` must be a finite, countable collection")
+   (if (seq coll)
+     (let [coll'     (if (vector? coll) coll (vec (seq coll)))
+           generator (or *global-generator* (impl/->generator seed))
+           size      (count coll')]
+       (repeatedly #(nth coll' (impl/next-int! generator size))))
+     '())))
+
+
+(defn weighted-sample
+  "Returns a lazy sequence of samples from `coll` using an internal random generator, selecting each item `i` with a probability of `(weight-fn i)`.
+   Requires that `coll` is a finite, countable collection that can be realized.
+   If `coll` is empty, an empty sequence is returned.
+   `weight-fn` must be a function that takes an item from `coll` and returns a non-negative probability weight.
+
+   A seed can be provided to create reproducible sequences, otherwise a random seed is used.
+
+   Examples:
+
+   ```clj
+   (take 3 (weighted-sample inc (range 99)))
+   ; => (16 92 91)
+
+   (first (weighted-sample (fn [x] (if (even? x) 1 0)) [1 2 3 4 5 6 7 8 9 10]))
+   ; => 2
+
+   (-> (weighted-sample :score [{:name \"Alice\" :score 10}
+                                {:name \"Bob\" :score 20}
+                                {:name \"Charlie\" :score 30}])
+       first
+       :name)
+   ```
+
+   `coll` can be:
+      - a vector
+      - a list
+      - a finite lazy sequence
+      - a set
+      - a hashmap
+      - a string
+
+   `seed` can be any value that can be cast to a string."
+  ([weight-fn coll]
+   (if (seq coll)
+     (weighted-sample impl/generate-seed weight-fn coll)
+     '()))
+  ([seed weight-fn coll]
+   (assert (seqable? coll) "`coll` must be a finite, countable collection")
+   (assert (ifn? weight-fn) "`weight-fn` must implement IFn.")
+   (if (seq coll)
+     (let [coll'                 (if (vector? coll) coll (vec (seq coll)))
+           generator             (or *global-generator* (impl/->generator seed))
+           incremental-weighting (impl/apply-weights weight-fn coll')
+           total-weight          (first (last incremental-weighting))]
+       (repeatedly #(second (first (subseq incremental-weighting > (impl/next-double! generator total-weight))))))
+     '())))

--- a/src/brew_bot/sampling/impl.cljc
+++ b/src/brew_bot/sampling/impl.cljc
@@ -1,0 +1,136 @@
+(ns brew-bot.sampling.impl
+  "The random number generating / sampling functionality of brew-bot.
+
+   This namespace backs the functionality of the `brew-bot.sampling.api` namespace, and is not intended to be used directly.
+   This functionality is not guaranteed to be stable, may change without notice, and makes no claims/guarantees about cryptographic security.
+   If you are an external library consumer, please use truseted libraries for cryptographic security over this functionality."
+  {:added                "3.4"
+   :no-doc               true
+   :implementation-only  true
+   :not-for-external-use true})
+
+
+(def max-unsigned-32-bit-int
+  "The maximum unsigned 32-bit integer."
+  (Math/pow 2 32))
+
+
+(def max-signed-32-bit-int
+  "The maximum signed 32-bit integer."
+  (Math/pow 2 31))
+
+
+(defn xor-shift
+  "The xor-shift algorithm for 32-bit integers."
+  [n]
+  (-> n
+      (bit-xor (bit-shift-left n 13))
+      (bit-xor (unsigned-bit-shift-right n 17))
+      (bit-xor (bit-shift-left n 5))
+      (bit-and 0xffffffff)))
+
+
+(defn next!
+  "Returns the next long from the generator."
+  [generator bits]
+  (swap! generator xor-shift)
+  (unsigned-bit-shift-right @generator (- 32 bits)))
+
+
+(defprotocol WBRandom
+  "A Protocol for random number generation.
+   The `WB` prefix is shorthand for `Wall Brew` and is intended to prevent name collisions.
+  Intended as a platform agnostic implementation of 32-bit Xorshift."
+
+  (next-bitset!
+    [generator bits]
+    "Returns the next long from the generator."))
+
+
+(deftype WBRandomGenerator
+  [state]
+
+  WBRandom
+
+  (next-bitset!
+    [_this bits]
+    (next! state bits)))
+
+
+(defn generate-seed
+  "Generate a seed for the random number generator."
+  []
+  (rand-int max-signed-32-bit-int))
+
+
+(defn ->generator
+  "Create a new random number generator."
+  ([]
+   (->generator (generate-seed)))
+  ([seed]
+   (WBRandomGenerator. (atom (hash (str seed))))))
+
+
+(defn next-double!
+  "Returns the next double from the generator between 0.0 and 1.0.
+   If no generator is provided, a new one is created and discarded.
+   If a maximum value is provided, the value is scaled to that maximum."
+  ([]
+   (next-double! (->generator)))
+  ([generator]
+   (let [n (next-bitset! generator 32)]
+     (double (/ n max-unsigned-32-bit-int))))
+  ([generator max-value]
+   (* max-value (next-double! generator))))
+
+
+(defn next-int!
+  "Returns the next integert from the generator between 0 and 2^32.
+   If no generator is provided, a new one is created and discarded.
+    If a maximum value is provided, the value is scaled to that maximum."
+  ([]
+   (next-int! (->generator)))
+  ([generator]
+   (next-bitset! generator 32))
+  ([generator max-value]
+   (int (* max-value (next-double! generator)))))
+
+
+(defn apply-weight
+  "Apply a weight function to a value.
+   The weight function must return a non-negative value.
+   The function returns a vector of the total weight and the value.
+
+   For example:
+   ```clj
+   (apply-weight inc 1)
+   ; => [2 1] ;; (inc 1)
+   ```
+   In the above example, the first element of the vector is the total weight of the value, and the second element is the value itself."
+  [weight-fn [total-weight previous-value] value]
+  (let [weight (weight-fn value)]
+    (cond
+      (pos? weight)  [(+ total-weight weight) value]
+      (zero? weight) [total-weight previous-value]
+      :else          (throw (ex-info "Weight function must return a non-negative value" {:value value})))))
+
+
+(defn apply-weights
+  "Apply a weight function to a collection of values.
+   The weight function must return a non-negative value.
+   The function returns a sorted map of the current weight and values.
+
+   For example:
+   ```clj
+   (apply-weights inc [1 2 3 4 5])
+   ; => {2 1,  ;; (inc 1)
+         5 2,  ;; (+ (inc 2) (inc 1))
+         9 3,  ;; (+ (inc 3) (inc 2) (inc 1))
+         14 4, ;; (+ (inc 4) (inc 3) (inc 2) (inc 1))
+         20 5} ;; (+ (inc 5) (inc 4) (inc 3) (inc 2) (inc 1))
+   ```
+   In the above example, the keys are the total weight of the values up to that point, and the values are the values themselves."
+  [weight-fn coll]
+  (->> (reductions (partial apply-weight weight-fn) [0] coll)
+       next
+       (into (sorted-map))))

--- a/src/brew_bot/styles.cljc
+++ b/src/brew_bot/styles.cljc
@@ -24,7 +24,7 @@
   "Determine on a normalized scale how close `data-point` was to `conforming-point` given the `scale`
    Shorter distances are scored higher, and currently this is determined quadratically"
   [scale conforming-point data-point]
-  (let [distance (Math/abs (- data-point conforming-point))
+  (let [distance          (Math/abs (- data-point conforming-point))
         fraction-of-scale (/ distance scale)]
     (Math/pow (- 1 fraction-of-scale) 2.0)))
 
@@ -35,8 +35,8 @@
    Assumes global-range and local-range to be order tuples"
   [global-range local-range data-point]
   (let [[global-low global-high] global-range
-        [local-low local-high] local-range
-        scale (- global-high global-low)]
+        [local-low local-high]   local-range
+        scale                    (- global-high global-low)]
     (cond
 
       ;; Detect points that are effectively out of bounds

--- a/src/brew_bot/util.cljc
+++ b/src/brew_bot/util.cljc
@@ -1,6 +1,6 @@
 (ns brew-bot.util
   "Common fns required across brew-bot"
-  (:require [nnichols.string :as nstr]))
+  (:require [com.wallbrew.spoon.string :as spoon.string]))
 
 
 (defn max-n-kv
@@ -51,9 +51,9 @@
   "Given a vector of common-beer-format conforming ::fermentable maps, determine if the recipe is 'Extract', 'Partial Mash', or 'All Grain'"
   [fermentables]
   (let [all-grain? (and (seq fermentables)
-                        (every? #(nstr/string-compare "grain" (:type %)) fermentables))
+                        (every? #(spoon.string/same-text? "grain" (:type %)) fermentables))
         all-extract? (and (seq fermentables)
-                          (every? #(contains? #{"sugar" "extract" "dry extract"} (nstr/prepare-for-compare (:type %))) fermentables))]
+                          (every? #(contains? #{"sugar" "extract" "dry extract"} (spoon.string/prepare-for-compare (:type %))) fermentables))]
     (cond
       all-grain?            "All Grain"
       all-extract?          "Extract"

--- a/test/brew_bot/runner.cljs
+++ b/test/brew_bot/runner.cljs
@@ -1,8 +1,10 @@
 (ns brew-bot.runner
   (:require [brew-bot.core-test]
+            [brew-bot.sampling.impl-test]
             [brew-bot.util-test]
             [doo.runner :refer-macros [doo-tests]]))
 
 
 (doo-tests 'brew-bot.core-test
+           'brew-bot.sampling.impl-test
            'brew-bot.util-test)

--- a/test/brew_bot/sampling/api_test.cljc
+++ b/test/brew_bot/sampling/api_test.cljc
@@ -1,0 +1,13 @@
+(ns brew-bot.sampling.api-test
+  (:require [brew-bot.sampling.api :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest with-seed-test
+  (testing "An encapsulating `with-seed` should behave the same as re-using a generator."
+    (let [seed     12
+          response "caaebcdeccabaaccaeeabdbcd"]
+      (sut/with-seed seed
+        (is (= response
+               (apply str (take 25 (sut/sample "abcde"))))))
+      (is (= response
+             (apply str (take 25 (sut/sample seed "abcde"))))))))

--- a/test/brew_bot/sampling/api_test.cljc
+++ b/test/brew_bot/sampling/api_test.cljc
@@ -2,12 +2,13 @@
   (:require [brew-bot.sampling.api :as sut]
             [clojure.test :refer [deftest is testing]]))
 
+
 (deftest with-seed-test
   (testing "An encapsulating `with-seed` should behave the same as re-using a generator."
     (let [seed     12
           response "caaebcdeccabaaccaeeabdbcd"]
       (sut/with-seed seed
-        (is (= response
-               (apply str (take 25 (sut/sample "abcde"))))))
+                     (is (= response
+                            (apply str (take 25 (sut/sample "abcde"))))))
       (is (= response
              (apply str (take 25 (sut/sample seed "abcde"))))))))

--- a/test/brew_bot/sampling/impl_test.cljc
+++ b/test/brew_bot/sampling/impl_test.cljc
@@ -1,0 +1,73 @@
+(ns brew-bot.sampling.impl-test
+  (:require [brew-bot.sampling.impl :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+
+(deftest xor-shift-test
+  (testing "Sanity testing xor-shift functionality"
+    (is (= 0 (sut/xor-shift 0)))
+    (is (= 8225 (sut/xor-shift 1)))
+    (is (= 82250 (sut/xor-shift 10)))))
+
+
+(deftest generate-seed-test
+  (testing "Ensure seeds are generated within the correct range"
+    (is (<= 0 (sut/generate-seed)))
+    (is (< (sut/generate-seed) sut/max-signed-32-bit-int))))
+
+
+(deftest next-bitset!-test
+  (testing "Ensure the next! function returns the correct values"
+    (let [generator (sut/->generator 0)]
+      (is (= 833194525 (sut/next-bitset! generator 32)))
+      (is (= 903573865 (sut/next-bitset! generator 32)))
+      (is (= 3768084132 (sut/next-bitset! generator 32)))))
+  (testing "Ensure next works with other types of seed"
+    (is (number? (sut/next-bitset! (sut/->generator) 32)))
+    (is (= 296680929
+           (sut/next-bitset! (sut/->generator "hello") 32)))
+    (is (= 2759485929
+           (sut/next-bitset! (sut/->generator :bye) 32)))))
+
+
+(deftest next-double!-test
+  (testing "Ensure the next-double! function returns the correct values"
+    (let [generator (sut/->generator 0)
+          data      (repeatedly 1000 #(sut/next-double! generator))]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % 1)) data)))
+    (let [data (repeatedly 1000 sut/next-double!)]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % 1)) data)))
+    (let [maximum  sut/max-signed-32-bit-int
+          generator (sut/->generator 0)
+          data (repeatedly 1000 #(sut/next-double! generator maximum))]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % maximum)) data)))))
+
+
+(deftest next-int!-test
+  (testing "Ensure the next-int! function returns the correct values"
+    (let [generator (sut/->generator 0)
+          data      (repeatedly 1000 #(sut/next-int! generator))]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % sut/max-unsigned-32-bit-int)) data)))
+    (let [data (repeatedly 1000 sut/next-int!)]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % sut/max-unsigned-32-bit-int)) data)))
+    (let [maximum   sut/max-signed-32-bit-int
+          generator (sut/->generator 0)
+          data      (repeatedly 1000 #(sut/next-int! generator maximum))]
+      (is (every? number? data))
+      (is (every? #(and (<= 0 %) (< % maximum)) data)))))
+
+
+(deftest apply-weights-test
+  (is (= [3 1]
+         (sut/apply-weight inc [1 1] 1)))
+  (is (= {2 1
+          5 2
+          9 3
+          14 4
+          20 5}
+         (sut/apply-weights inc [1 2 3 4 5]))))

--- a/test/brew_bot/util_test.cljc
+++ b/test/brew_bot/util_test.cljc
@@ -5,8 +5,12 @@
             [common-beer-data.core :as data]
             [common-beer-format.fermentables :as fermentables]
             [common-beer-format.hops :as hops]
-            [common-beer-format.yeasts :as yeasts]
-            [nnichols.util :as nu]))
+            [common-beer-format.yeasts :as yeasts]))
+
+
+(def rand-val
+  "Like `rand-nth`, but for the values of a map"
+  (comp rand-nth vals))
 
 
 (deftest min-max-kv-test
@@ -20,16 +24,16 @@
 
 (deftest transformer-tests
   (testing "Ensure all common-beer-format transformers create valid wrappers"
-    (let [random-fermentables (sut/fermentables->cbf-fermentables (take 100 (repeatedly #(nu/rand-val data/all-fermentables))))
-          sample-fermentable  (nu/rand-val data/all-fermentables)
-          random-hops         (sut/hops->cbf-hops (take 100 (repeatedly #(nu/rand-val data/all-hops))))
-          sample-hop          (nu/rand-val data/all-hops)
-          random-yeasts       (sut/yeasts->cbf-yeasts (take 100 (repeatedly #(nu/rand-val data/all-yeasts))))
-          sample-yeast        (nu/rand-val data/all-yeasts)]
+    (let [random-fermentables (sut/fermentables->cbf-fermentables (take 100 (repeatedly #(rand-val data/all-fermentables))))
+          sample-fermentable  (rand-val data/all-fermentables)
+          random-hops         (sut/hops->cbf-hops (take 100 (repeatedly #(rand-val data/all-hops))))
+          sample-hop          (rand-val data/all-hops)
+          random-yeasts       (sut/yeasts->cbf-yeasts (take 100 (repeatedly #(rand-val data/all-yeasts))))
+          sample-yeast        (rand-val data/all-yeasts)]
       (is (spoon.spec/test-valid? ::fermentables/fermentables random-fermentables))
       (is (false? (empty? random-fermentables)))
       (is (distinct? (map #(get-in % [:fermentable :name]) random-fermentables)))
-      (is (= 3 (:amount (:fermentable (nu/only (sut/fermentables->cbf-fermentables [(assoc sample-fermentable :amount 1) (assoc sample-fermentable :amount 2)]))))))
+      (is (= 3 (:amount (:fermentable (first (sut/fermentables->cbf-fermentables [(assoc sample-fermentable :amount 1) (assoc sample-fermentable :amount 2)]))))))
       (is (spoon.spec/test-valid? ::hops/hops random-hops))
       (is (false? (empty? random-hops)))
       (is (distinct? (map #(get-in % [:fermentable :name]) random-hops)))
@@ -39,21 +43,21 @@
       (is (spoon.spec/test-valid? ::yeasts/yeasts random-yeasts))
       (is (false? (empty? random-yeasts)))
       (is (distinct? (map #(get-in % [:fermentable :name]) random-yeasts)))
-      (is (= 3 (:amount (:yeast (nu/only (sut/yeasts->cbf-yeasts [(assoc sample-yeast :amount 1) (assoc sample-yeast :amount 2)])))))))))
+      (is (= 3 (:amount (:yeast (first (sut/yeasts->cbf-yeasts [(assoc sample-yeast :amount 1) (assoc sample-yeast :amount 2)])))))))))
 
 
 (deftest determine-recipe-type-test
   (testing "Ensure the correct recipe type is selected based on the ingredients"
     #?(:clj (is (thrown-with-msg? Exception #"Cannot determine recipe type with an empty collection of fermentables" (sut/determine-recipe-type []))))
     #?(:cljs (is (thrown-with-msg? js/Error #"Cannot determine recipe type with an empty collection of fermentables" (sut/determine-recipe-type []))))
-    (is (= "All Grain" (sut/determine-recipe-type (take 10 (repeatedly #(nu/rand-val (data/select-fermentables {:include-grains? true})))))))
-    (is (= "Extract" (sut/determine-recipe-type (take 10 (repeatedly #(nu/rand-val (data/select-fermentables {:include-sugars? true :include-dry-extracts? true :include-extracts? true})))))))
-    (is (= "Partial Mash" (sut/determine-recipe-type (concat (take 10 (repeatedly #(nu/rand-val (data/select-fermentables {:include-grains? true})))) (take 10 (repeatedly #(nu/rand-val (data/select-fermentables {:include-sugars? true :include-dry-extracts? true :include-extracts? true}))))))))))
+    (is (= "All Grain" (sut/determine-recipe-type (take 10 (repeatedly #(rand-val (data/select-fermentables {:include-grains? true})))))))
+    (is (= "Extract" (sut/determine-recipe-type (take 10 (repeatedly #(rand-val (data/select-fermentables {:include-sugars? true :include-dry-extracts? true :include-extracts? true})))))))
+    (is (= "Partial Mash" (sut/determine-recipe-type (concat (take 10 (repeatedly #(rand-val (data/select-fermentables {:include-grains? true})))) (take 10 (repeatedly #(rand-val (data/select-fermentables {:include-sugars? true :include-dry-extracts? true :include-extracts? true}))))))))))
 
 
 (deftest determine-boil-time-test
   (testing "Ensure boil times are appropriately calculated"
-    (let [sample-hop (nu/rand-val data/all-hops)]
+    (let [sample-hop (rand-val data/all-hops)]
       (is (= 60 (sut/determine-boil-time [])))
       (is (= 60 (sut/determine-boil-time [(assoc sample-hop :time 15) (assoc sample-hop :time 30) (assoc sample-hop :time 45)])))
       (is (= 90 (sut/determine-boil-time [(assoc sample-hop :time 15) (assoc sample-hop :time 90) (assoc sample-hop :time 45)]))))))


### PR DESCRIPTION
# Proposed Changes

* Added
  * Ingredient sampling functions `brew-bot.sampling.api/sample` and `brew-bot.sampling.api/weighted-sample`.
  * A macro `brew-bot.sampling.api/with-seed` to set a seed for the internal random generator over multiple sampling calls.
* Removed
  * Dependency on `cljx-sampling` has been removed.

## Pre-merge Checklist

- [x] Read and agree to the Contribution Guidelines and Code of Conduct
- [x] Write new tests for impacted functionality
- [x] Update the CHANGELOG and increment version
- [x] Update the README and other relevant documentation
